### PR TITLE
Add basic Flutter skeleton

### DIFF
--- a/lib/ai/prompt_generator.dart
+++ b/lib/ai/prompt_generator.dart
@@ -1,0 +1,3 @@
+class PromptGenerator {
+  // Placeholder for prompt generation logic
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'screens/home_screen.dart';
+
+class AppModel extends ChangeNotifier {
+  // Placeholder ChangeNotifier for app state management
+}
+
+void main() {
+  runApp(const EcoLaliaApp());
+}
+
+class EcoLaliaApp extends StatelessWidget {
+  const EcoLaliaApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => AppModel(),
+      child: MaterialApp(
+        title: 'Eco Lalia',
+        theme: ThemeData(primarySwatch: Colors.green),
+        home: const HomeScreen(),
+      ),
+    );
+  }
+}

--- a/lib/models/ecolalia.dart
+++ b/lib/models/ecolalia.dart
@@ -1,0 +1,6 @@
+class Ecolalia {
+  final String text;
+  final DateTime date;
+
+  Ecolalia({required this.text, required this.date});
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'record_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Eco Lalia Home')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const RecordScreen()),
+            );
+          },
+          child: const Text('Go to Record'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/record_screen.dart
+++ b/lib/screens/record_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class RecordScreen extends StatelessWidget {
+  const RecordScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Record Ecolalia')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            // Simulate recording action
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Recording...')),
+            );
+          },
+          child: const Text('Record'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/suggestions_screen.dart
+++ b/lib/screens/suggestions_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class SuggestionsScreen extends StatelessWidget {
+  const SuggestionsScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Suggestions')),
+      body: const Center(child: Text('Suggestions will appear here.')),
+    );
+  }
+}

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -1,0 +1,3 @@
+class AIService {
+  // Placeholder for AI-related operations
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -1,0 +1,3 @@
+class StorageService {
+  // Placeholder for storage operations using Hive or other storage solutions
+}

--- a/lib/widgets/custom_button.dart
+++ b/lib/widgets/custom_button.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class CustomButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+
+  const CustomButton({Key? key, required this.label, required this.onPressed})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(onPressed: onPressed, child: Text(label));
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,24 @@
+name: eco_lalia
+version: 1.0.0+1
+description: A Flutter project for Ecolalia app
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.0
+  http: ^0.13.0
+  flutter_tts: ^3.5.2
+  speech_to_text: ^5.9.0
+  path_provider: ^2.0.9
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- initialize Flutter project structure with pubspec and lib files
- add navigation with provider in `main.dart`
- scaffold `HomeScreen`, `RecordScreen`, and other placeholder files

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bf29dd4c832f96cdbb5975063136